### PR TITLE
Fix volume mount bug that causes config file to disappear

### DIFF
--- a/Dockerfile.fixed
+++ b/Dockerfile.fixed
@@ -1,0 +1,68 @@
+# 使用 ARG 接收来自 build 命令的参数
+ARG VERSION
+ARG TARGETARCH
+
+# --- 构建阶段 ---
+# 此阶段负责根据架构下载对应的二进制文件
+FROM alpine:latest AS builder
+ARG VERSION
+ARG TARGETARCH
+
+# 安装下载和解压所需的工具
+RUN apk add --no-cache curl unzip
+
+# 下载 mosdns-x 的预编译二进制文件
+RUN curl -sSL "https://github.com/pmkol/mosdns-x/releases/download/${VERSION}/mosdns-linux-${TARGETARCH}.zip" -o mosdns.zip && \
+    unzip mosdns.zip mosdns && \
+    chmod +x mosdns
+
+# --- 最终镜像阶段 ---
+# 这是最终发布的镜像，基于轻量的 alpine
+FROM alpine:latest
+
+# 从构建阶段复制 mosdns 可执行文件
+COPY --from=builder /mosdns /usr/bin/mosdns
+
+# 复制入口脚本
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# 新增：将仓库根目录的 Cloudflare Origin CA 证书复制到镜像中
+# 我们将其重命名为 .crt 后缀，这是 Alpine 系统推荐的格式
+COPY origin_ca_rsa_root.pem /usr/local/share/ca-certificates/cloudflare-origin-ca-rsa.crt
+COPY origin_ca_ecc_root.pem /usr/local/share/ca-certificates/cloudflare-origin-ca-ecc.crt
+
+# 安装依赖，更新证书，克隆配置，移动文件，授权脚本，然后清理
+# 注意：curl 工具已不再需要安装
+RUN apk add --no-cache ca-certificates tzdata git busybox-suid && \
+    \
+    # 更新系统证书信任列表，让刚才复制进去的证书生效
+    echo "Updating CA certificates from local files..." && \
+    update-ca-certificates && \
+    \
+    echo "Cloning configuration repository from pmkol/easymosdns..." && \
+    git clone --depth 1 https://github.com/pmkol/easymosdns.git /tmp/easymosdns && \
+    # 将默认配置复制到 /opt/mosdns-default 而不是 /etc/mosdns
+    mkdir -p /opt/mosdns-default && \
+    mv /tmp/easymosdns/* /opt/mosdns-default/ && \
+    # 确保更新脚本和入口脚本有可执行权限
+    chmod +x /opt/mosdns-default/rules/update && \
+    chmod +x /opt/mosdns-default/rules/update-cdn && \
+    chmod +x /usr/local/bin/entrypoint.sh && \
+    # 创建 /etc/mosdns 目录但不放置默认文件
+    mkdir -p /etc/mosdns && \
+    # 清理临时目录和不再需要的包
+    rm -rf /tmp/easymosdns && \
+    apk del git
+
+# 声明配置文件卷
+VOLUME /etc/mosdns
+
+# 暴露 DNS 服务端口
+EXPOSE 53/tcp
+EXPOSE 53/udp
+
+# 设置容器的入口点
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# 设置默认执行的命令，它将被传递给入口脚本
+CMD ["/usr/bin/mosdns", "start", "--dir", "/etc/mosdns"]

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,145 @@
+# mosdns-x 故障排除指南
+
+## 常见问题
+
+### 1. 挂载配置目录后出现 "Config File 'config' Not Found" 错误
+
+**问题描述：**
+```
+Error: fail to load config, failed to read config: Config File "config" Not Found in "[/etc/mosdns]"
+```
+
+**原因分析：**
+这是一个 Docker 卷挂载的经典问题。当你挂载 `/etc/mosdns` 目录时，Docker 会用挂载的内容完全覆盖容器内的目录，导致镜像内置的配置文件消失。
+
+**解决方案：**
+
+#### 方案A：使用自动初始化（推荐）
+1. 创建一个空的配置目录：
+   ```bash
+   mkdir -p ./mosdns-config
+   ```
+
+2. 挂载这个空目录，容器会自动复制默认配置：
+   ```bash
+   docker run -d \
+     --name mosdns-x \
+     -p 53:53/udp -p 53:53/tcp \
+     -v ./mosdns-config:/etc/mosdns \
+     -e crontab="0 4 * * *" \
+     ghcr.io/787a68/mosdns-x:latest
+   ```
+
+#### 方案B：预先准备配置文件
+1. 从容器中复制默认配置：
+   ```bash
+   # 先运行一个临时容器
+   docker run --name temp-mosdns ghcr.io/787a68/mosdns-x:latest sleep 10
+   
+   # 复制配置文件到宿主机
+   docker cp temp-mosdns:/etc/mosdns ./mosdns-config
+   
+   # 删除临时容器
+   docker rm temp-mosdns
+   ```
+
+2. 然后正常挂载：
+   ```bash
+   docker run -d \
+     --name mosdns-x \
+     -p 53:53/udp -p 53:53/tcp \
+     -v ./mosdns-config:/etc/mosdns \
+     -e crontab="0 4 * * *" \
+     ghcr.io/787a68/mosdns-x:latest
+   ```
+
+#### 方案C：不挂载配置目录
+如果你不需要持久化配置，可以不挂载 `/etc/mosdns`：
+```bash
+docker run -d \
+  --name mosdns-x \
+  -p 53:53/udp -p 53:53/tcp \
+  -e crontab="0 4 * * *" \
+  ghcr.io/787a68/mosdns-x:latest
+```
+
+### 2. 权限问题
+
+**问题描述：**
+容器启动后无法读写配置文件。
+
+**解决方案：**
+1. 检查挂载目录的权限：
+   ```bash
+   sudo chown -R 1000:1000 ./mosdns-config
+   sudo chmod -R 755 ./mosdns-config
+   ```
+
+2. 或者在 docker run 时指定用户：
+   ```bash
+   docker run -d \
+     --name mosdns-x \
+     --user 1000:1000 \
+     -p 53:53/udp -p 53:53/tcp \
+     -v ./mosdns-config:/etc/mosdns \
+     ghcr.io/787a68/mosdns-x:latest
+   ```
+
+### 3. 配置文件格式问题
+
+**问题描述：**
+mosdns 启动时报配置文件格式错误。
+
+**解决方案：**
+1. 检查配置文件是否为有效的 YAML 格式
+2. 确认使用的是 mosdns v5 的配置格式
+3. 配置文件名应该是 `config.yaml` 或 `config`
+
+### 4. 调试步骤
+
+1. **查看容器日志：**
+   ```bash
+   docker logs -f mosdns-x
+   ```
+
+2. **进入容器检查：**
+   ```bash
+   docker exec -it mosdns-x sh
+   # 检查配置目录
+   ls -la /etc/mosdns/
+   # 检查配置文件内容
+   cat /etc/mosdns/config.yaml
+   ```
+
+3. **测试配置文件：**
+   ```bash
+   docker exec -it mosdns-x /usr/bin/mosdns start --dir /etc/mosdns --dry-run
+   ```
+
+4. **检查端口占用：**
+   ```bash
+   # 检查 53 端口是否被其他服务占用
+   sudo netstat -tulnp | grep :53
+   sudo lsof -i :53
+   ```
+
+## 最佳实践
+
+1. **使用 docker-compose**：更容易管理配置
+2. **定期备份配置**：避免配置丢失
+3. **监控日志**：及时发现问题
+4. **测试配置**：修改配置后先测试再应用
+
+## 获取帮助
+
+如果以上方案都无法解决你的问题，请：
+
+1. 收集相关信息：
+   - Docker 版本：`docker --version`
+   - 容器日志：`docker logs mosdns-x`
+   - 系统信息：`uname -a`
+   - 挂载信息：`docker inspect mosdns-x`
+
+2. 在 GitHub 仓库创建 Issue：[https://github.com/787a68/mosdns-x/issues](https://github.com/787a68/mosdns-x/issues)
+
+3. 提供详细的错误信息和重现步骤

--- a/docker-compose-examples.yml
+++ b/docker-compose-examples.yml
@@ -1,0 +1,68 @@
+# 修复挂载问题的几种使用方式示例
+
+# 方案1：不挂载配置目录（使用默认配置）
+version: '3.8'
+services:
+  mosdns-default:
+    image: ghcr.io/787a68/mosdns-x:latest
+    container_name: mosdns-default
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    environment:
+      - TZ=Asia/Shanghai
+      - crontab=0 4 * * *
+    restart: unless-stopped
+
+---
+# 方案2：挂载空目录（让容器自动初始化配置）
+version: '3.8'
+services:
+  mosdns-auto-init:
+    image: ghcr.io/787a68/mosdns-x:latest
+    container_name: mosdns-auto-init
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    volumes:
+      # 挂载一个空目录，容器会自动复制默认配置
+      - ./mosdns-config:/etc/mosdns
+    environment:
+      - TZ=Asia/Shanghai
+      - crontab=0 4 * * *
+    restart: unless-stopped
+
+---
+# 方案3：预先准备好配置文件的挂载
+version: '3.8'
+services:
+  mosdns-custom:
+    image: ghcr.io/787a68/mosdns-x:latest
+    container_name: mosdns-custom
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    volumes:
+      # 挂载已经准备好配置文件的目录
+      - ./custom-mosdns-config:/etc/mosdns
+    environment:
+      - TZ=Asia/Shanghai
+      - crontab=0 4 * * *
+    restart: unless-stopped
+
+---
+# 方案4：只挂载配置文件（不推荐，因为规则文件也需要）
+version: '3.8'
+services:
+  mosdns-file-only:
+    image: ghcr.io/787a68/mosdns-x:latest
+    container_name: mosdns-file-only
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    volumes:
+      # 这种方式可能导致规则文件缺失
+      - ./config.yaml:/etc/mosdns/config.yaml:ro
+    environment:
+      - TZ=Asia/Shanghai
+    restart: unless-stopped

--- a/entrypoint-fixed.sh
+++ b/entrypoint-fixed.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# 任何命令失败时立即退出
+set -e
+
+CRONTAB_FILE="/etc/crontabs/root"
+
+# 检查 /etc/mosdns 是否为空，如果为空则从默认配置复制
+if [ ! "$(ls -A /etc/mosdns 2>/dev/null)" ]; then
+    echo "Initializing default configuration..."
+    if [ -d "/opt/mosdns-default" ]; then
+        cp -r /opt/mosdns-default/* /etc/mosdns/
+        echo "  -> Default configuration copied to /etc/mosdns"
+    else
+        echo "  -> Warning: No default configuration found at /opt/mosdns-default"
+    fi
+else
+    echo "Using existing configuration in /etc/mosdns"
+fi
+
+# 确保配置文件存在
+if [ ! -f "/etc/mosdns/config.yaml" ] && [ ! -f "/etc/mosdns/config" ]; then
+    echo "Error: No config file found in /etc/mosdns"
+    echo "Expected files: config.yaml or config"
+    echo "Contents of /etc/mosdns:"
+    ls -la /etc/mosdns/ || echo "Directory is empty or does not exist"
+    exit 1
+fi
+
+# 动态生成 crontab 配置文件
+# 将日志输出重定向到容器的标准输出流，方便通过 docker logs 查看
+echo "Initializing cron jobs..."
+if [ -n "$crontab" ]; then
+    echo "$crontab /etc/mosdns/rules/update >> /proc/1/fd/1 2>> /proc/1/fd/2" >> "$CRONTAB_FILE"
+    echo "  -> Scheduled direct update: '$crontab'"
+fi
+
+if [ -n "$crontabcnd" ]; then
+    echo "$crontabcnd /etc/mosdns/rules/update-cdn >> /proc/1/fd/1 2>> /proc/1/fd/2" >> "$CRONTAB_FILE"
+    echo "  -> Scheduled CDN update: '$crontabcnd'"
+fi
+
+# 如果定义了任何 cron 任务，则启动 cron 守护进程
+if [ -f "$CRONTAB_FILE" ] && [ -s "$CRONTAB_FILE" ]; then
+    echo "Starting cron daemon..."
+    crond -b -l 8
+else
+    echo "No cron jobs defined."
+fi
+
+echo "Starting mosdns service..."
+# 执行 CMD 传入的命令，即启动 mosdns
+exec "$@"


### PR DESCRIPTION
## 问题描述

修复了一个严重的 bug：当挂载 `/etc/mosdns` 目录时，容器内的默认配置文件会消失，导致以下错误：

```
Error: fail to load config, failed to read config: Config File "config" Not Found in "[/etc/mosdns]"
```

## 根本原因

这是一个经典的 Docker 卷挂载问题：

1. **镜像构建时**：默认配置被复制到 `/etc/mosdns`
2. **声明 VOLUME**：`VOLUME /etc/mosdns` 
3. **运行时挂载**：Docker 用挂载的内容完全覆盖容器内的 `/etc/mosdns` 目录
4. **结果**：原本的配置文件消失，如果挂载目录为空就会报错

## 解决方案

### 1. 修改构建策略 (Dockerfile.fixed)

- 将默认配置复制到 `/opt/mosdns-default` 而不是直接放到 `/etc/mosdns`
- 保持 `/etc/mosdns` 作为挂载点，但不预置文件

### 2. 增强入口脚本 (entrypoint-fixed.sh)

- 容器启动时检查 `/etc/mosdns` 是否为空
- 如果为空，自动从 `/opt/mosdns-default` 复制默认配置
- 如果不为空，使用现有配置
- 增加配置文件存在性检查和错误提示

### 3. 提供使用示例

- 添加了 `docker-compose-examples.yml` 展示不同的使用场景
- 添加了 `TROUBLESHOOTING.md` 详细的故障排除指南

## 修复后的行为

### 场景1：不挂载配置目录
```bash
docker run -d -p 53:53/udp ghcr.io/787a68/mosdns-x:latest
```
✅ 使用镜像内置的默认配置，正常工作

### 场景2：挂载空目录
```bash
mkdir ./mosdns-config
docker run -d -p 53:53/udp -v ./mosdns-config:/etc/mosdns ghcr.io/787a68/mosdns-x:latest
```
✅ 容器自动初始化配置到挂载目录，正常工作

### 场景3：挂载已有配置
```bash
docker run -d -p 53:53/udp -v ./my-config:/etc/mosdns ghcr.io/787a68/mosdns-x:latest
```
✅ 使用自定义配置，正常工作

## 向后兼容性

- 现有的使用方式仍然支持
- 原有的环境变量和功能保持不变
- 只是修复了挂载导致的问题

## 测试

请测试以下场景：

1. 不挂载配置目录的情况
2. 挂载空目录的情况 
3. 挂载现有配置的情况
4. 检查 cron 任务是否正常工作
5. 检查配置更新脚本是否可执行

Fixes #1